### PR TITLE
Fix affected resources overflow

### DIFF
--- a/CommonUI/src/Components/EventItem/EventItem.tsx
+++ b/CommonUI/src/Components/EventItem/EventItem.tsx
@@ -143,7 +143,7 @@ const EventItem: FunctionComponent<ComponentProps> = (
                 {props.eventResourcesAffected &&
                 props.eventResourcesAffected?.length > 0 ? (
                     <div key={0}>
-                        <div className="flex space-x-1">
+                        <div className="flex flex-wrap gap-y-4 space-x-1">
                             <div className="text-sm text-gray-400 mr-3 mt-1">
                                 Affected resources
                             </div>


### PR DESCRIPTION
### Title of this pull request?
Affected resources exceed width in status page

### Small Description?
The affected resources exceed the width of the status page when there are too many of them

### Screenshots (if appropriate):
![desktop](https://github.com/DamsDev1/oneuptime/assets/60252259/94b66c5e-7c6f-47c5-a9f0-0d88236f48ae)
